### PR TITLE
Fix quoting for RemoteApp name

### DIFF
--- a/bin/winapps
+++ b/bin/winapps
@@ -588,7 +588,7 @@ function waRunCommand() {
                 +auto-reconnect \
                 /drive:media,"$REMOVABLE_MEDIA" \
                 /wm-class:"$FULL_NAME" \
-                /app:program:"$WIN_EXECUTABLE",icon:"$ICON",name:$"FULL_NAME",cmd:\""$FILE_PATH"\" \
+                /app:program:"$WIN_EXECUTABLE",icon:"$ICON",name:"$FULL_NAME",cmd:\""$FILE_PATH"\" \
                 /v:"$RDP_IP" &>/dev/null &
 
             # Capture the process ID.


### PR DESCRIPTION
## Summary
- correct quoting for `$FULL_NAME` when launching with a file path

## Testing
- `shellcheck bin/winapps`

------
https://chatgpt.com/codex/tasks/task_e_688acf6a6b988326a4013c427f51390b