### PR TITLE
Fix typo in setup info comments

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1279,7 +1279,7 @@ function waConfigureApp() {
 
     # Source 'Info' File Containing:
     # - The Application Name          (FULL_NAME)
-    # - The Shortcut Nsame            (NAME)
+    # - The Shortcut Name             (NAME)
     # - Application Categories        (CATEGORIES)
     # - Executable Path               (WIN_EXECUTABLE)
     # - Supported MIME Types          (MIME_TYPES)
@@ -1379,7 +1379,7 @@ function waConfigureApps() {
     for OSA in "${OSA_LIST[@]}"; do
         # Source 'Info' File Containing:
         # - The Application Name          (FULL_NAME)
-        # - The Shortcut Nsame            (NAME)
+        # - The Shortcut Name             (NAME)
         # - Application Categories        (CATEGORIES)
         # - Executable Path               (WIN_EXECUTABLE)
         # - Supported MIME Types          (MIME_TYPES)


### PR DESCRIPTION
## Summary
- fix `The Shortcut Nsame` typo and adjust spacing to align parentheses

## Testing
- `grep -n "Shortcut Name" -n setup.sh | head`


------
https://chatgpt.com/codex/tasks/task_e_688ad228f3dc83269fba6c25923316a4