### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ RDP_SCALE="100"
 #   This improves compatibility with most desktop environments (DEs).
 # ATTENTION: The Filesystem Hierarchy Standard (FHS) recommends /media instead. Verify your system's configuration.
 # - To manually mount devices, you may optionally use /mnt.
-# REFERRENCE: https://wiki.archlinux.org/title/Udisks#Mount_to_/media
+# REFERENCE: https://wiki.archlinux.org/title/Udisks#Mount_to_/media
 REMOVABLE_MEDIA="/run/media"
 
 # [ADDITIONAL FREERDP FLAGS & ARGUMENTS]


### PR DESCRIPTION
## Summary
- correct spelling mistake in README

## Testing
- `grep -n "REFERENCE" -n README.md | head`


------
https://chatgpt.com/codex/tasks/task_e_688ada195ca48326bcfb9d9fbd5ee316