### PR TITLE
Fix comment typo

### DIFF
--- a/install/ExtractPrograms.ps1
+++ b/install/ExtractPrograms.ps1
@@ -49,7 +49,7 @@ Function GetApplicationIcon {
 # Args:
 #    - 'Names': An array of application names.
 #    - 'Paths': An array of executable paths.
-#    - 'Source': The source of the applications (e.g. Windows Registry, Package manangers, Universal Windows Platform (UWP), etc.)
+#    - 'Source': The source of the applications (e.g. Windows Registry, Package managers, Universal Windows Platform (UWP), etc.)
 function PrintArrayData {
     param (
         [string[]]$Names,


### PR DESCRIPTION
## Summary
- correct `manangers` typo in `PrintArrayData` argument description

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688ada31f1f4832689564541ef0988bf