### PR TITLE
Fix compose disk mapping comment

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -44,6 +44,6 @@ services:
       # NOTE: 'disk1' will be mounted as the main drive. THIS DISK WILL BE FORMATTED BY DOCKER.
       # All following disks (disk2, ...) WILL NOT BE FORMATTED.
       # - /dev/disk/by-id/<id>:/disk1
-      # - dev/disk/by-id/<id>:/disk2
+      # - /dev/disk/by-id/<id>:/disk2
     # group_add:      # uncomment this line and the next one for using rootless podman containers
     #   - keep-groups # to make /dev/kvm work with podman. needs "crun" installed, "runc" will not work! Add your user to the 'kvm' group or another that can access /dev/kvm.


### PR DESCRIPTION
## Summary
- correct disk2 mapping example to include root path

## Testing
- `docker compose config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c62d128548326b308703cfcd42d70