### PR TITLE
Fix minor grammar issue in license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,7 +8,7 @@ Due to lack of a license, it is All Rights Reserved by the original author.
 We have tried contacting Fmstrat about this, but they abandoned the project and did not reply nor apply an open-source license to the project.
 However, almost all parts of the codebase have been rewritten and all new contributions require a Contributor License Agreement ([for individuals](https://gist.github.com/oskardotglobal/35f0a72eb45fcc7087e535561383dbc5), [for legal entities](https://gist.github.com/oskardotglobal/75a8cc056e56a439fa6a1551129ae47f)) to be signed. Therefore, the below license is applied to all new contributions made to the project.
 
-Refer to a specific file for it's respective license.
+Refer to a specific file for its respective license.
 
 # GNU AFFERO GENERAL PUBLIC LICENSE
 


### PR DESCRIPTION
## Summary
- fix typo: "it's respective license" -> "its respective license"

## Testing
- `nix --accept-flake-config --extra-experimental-features 'nix-command flakes' build` *(fails: unable to download from cache.nixos.org)*

------
https://chatgpt.com/codex/tasks/task_e_688c6540ed68832690a17e7cf6d38e87